### PR TITLE
Replace PIL with Pillow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ Flask-WTF==0.9.1
 Jinja2==2.7.1
 Mako==0.8.1
 MarkupSafe==0.18
-PIL==1.1.7
+pillow==1.7.8
 PyYAML==3.10
 SQLAlchemy==0.8.2
 WTForms==1.0.4


### PR DESCRIPTION
A [recent build failed](https://travis-ci.org/codeforamerica/bizfriendly-api/builds/18432445) on `pip install PIL`. Pillow is a fork of PIL that attempts to [address PIL’s install problems](https://pypi.python.org/pypi/Pillow/1.7.8#introduction), and might help Travis pass a test.

This branch is not tested.
